### PR TITLE
Build was failing with "android gradle plugin version 2.4.0-alpha7 is…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.4.0-alpha7'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
… too old"

- Modifying the version to be able to compile the project with Android Studio 2.3.3.

This will fix issue #10 opened by @xenomachina